### PR TITLE
Choosing media Source in CEF

### DIFF
--- a/getscreenmedia.js
+++ b/getscreenmedia.js
@@ -18,7 +18,7 @@ module.exports = function (constraints, cb) {
     if (window.navigator.userAgent.match('Chrome')) {
         var chromever = parseInt(window.navigator.userAgent.match(/Chrome\/(.*) /)[1], 10);
         var maxver = 33;
-        var isCef = !window.chrome.webstore || window.cefGetScreenMedia;
+        var isCef = !window.chrome.webstore;
         // "known" crash in chrome 34 and 35 on linux
         if (window.navigator.userAgent.match('Linux')) maxver = 35;
 
@@ -52,7 +52,7 @@ module.exports = function (constraints, cb) {
                     }
                 }
             );
-        } else if (isCef && window.cefGetScreenMedia) {
+        } else if (window.cefGetScreenMedia) {
             //window.cefGetScreenMedia is experimental - may be removed without notice
             window.cefGetScreenMedia(function(sourceId) {
                 if (!sourceId) {

--- a/getscreenmedia.js
+++ b/getscreenmedia.js
@@ -35,7 +35,7 @@ module.exports = function (constraints, cb) {
                         error.name = 'PERMISSION_DENIED';
                         callback(error);
                     } else {
-                        var constraints = constraints || {audio: false, video: {
+                        constraints = (hasConstraints && constraints) || {audio: false, video: {
                             mandatory: {
                                 chromeMediaSource: 'desktop',
                                 maxWidth: window.screen.width,
@@ -60,7 +60,7 @@ module.exports = function (constraints, cb) {
                     error.name = 'CEF_GETSCREENMEDIA_CANCELED';
                     callback(error);
                 } else {
-                    constraints = constraints || {audio: false, video: {
+                    constraints = (hasConstraints && constraints) || {audio: false, video: {
                         mandatory: {
                             chromeMediaSource: 'desktop',
                             maxWidth: window.screen.width,

--- a/getscreenmedia.js
+++ b/getscreenmedia.js
@@ -53,10 +53,11 @@ module.exports = function (constraints, cb) {
                 }
             );
         } else if (isCef && window.cefGetScreenMedia) {
+            //window.cefGetScreenMedia is experimental - may be removed without notice
             window.cefGetScreenMedia(function(sourceId) {
                 if (!sourceId) {
                     var error = new Error('cefGetScreenMediaError');
-                    error.name = 'CEF_GETSCREENMEDIA_CANCELLED';
+                    error.name = 'CEF_GETSCREENMEDIA_CANCELED';
                     callback(error);
                 } else {
                     constraints = constraints || {audio: false, video: {


### PR DESCRIPTION
Adding an experimental feature for choosing the screen/window in CEF by adding a call to `window.cefGetScreenMedia` which takes a callback to allow CEF to return a sourceId for choosing screen media source.